### PR TITLE
Bug fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Note ID
 
-The [Obsidian](https://www.obsidian.md/) Note ID Plugin displays notes by their ID, enabling structured sequences in a Zettelkasten ("Folgezettel").
+The [Obsidian](https://www.obsidian.md/) Note ID Plugin displays notes by their ID, enabling structured sequences for manuscripts or a Zettelkasten ("Folgezettel").
 
 ## Features
 

--- a/main.ts
+++ b/main.ts
@@ -543,20 +543,6 @@ class IDSidePanelSettingTab extends PluginSettingTab {
 					}),
 			);
 		new Setting(containerEl)
-			.setName("Table of contents title property")
-			.setDesc(
-				"Define the frontmatter field used as the title shown in the table of contents (case-insensitive).",
-			)
-			.addText((text) =>
-				text
-					.setPlaceholder(TOC_TITLE_FIELD_DEFAULT)
-					.setValue(this.plugin.settings.tocField)
-					.onChange(async (value) => {
-						this.plugin.settings.tocField = value.trim();
-						await this.plugin.saveSettings();
-					}),
-			);
-		new Setting(containerEl)
 			.setName("Include folders")
 			.setDesc(
 				"Only include notes from these folders. Leave empty to include all.",
@@ -617,35 +603,13 @@ class IDSidePanelSettingTab extends PluginSettingTab {
 		});
 
 		new Setting(containerEl)
-			.setName("Automatically include notes in table of contents")
-			.setDesc(
-				"If enabled, notes will be included in the table of contents based on their hierarchy level. " +
-					"If disabled, only notes with a 'toc' property will be shown.",
-			)
+			.setName("Indent notes")
+			.setDesc("Indents notes based on their id level.")
 			.addToggle((toggle) =>
 				toggle
-					.setValue(this.plugin.settings.autoToc)
+					.setValue(this.plugin.settings.indentation)
 					.onChange(async (value) => {
-						this.plugin.settings.autoToc = value;
-						await this.plugin.saveSettings();
-						this.display();
-					}),
-			);
-		new Setting(containerEl)
-			.setName("Table of contents level")
-			.setDesc(
-				"Defines which hierarchy level of notes should be included in the table of contents. " +
-					"A value of 1 includes only top-level notes (1, 2, …), 2 includes sub-levels (1.1, 1.2, …), and so on. " +
-					"Notes with a 'toc' property are always included.",
-			)
-			.addSlider((slider) =>
-				slider
-					.setLimits(1, 10, 1)
-					.setValue(this.plugin.settings.tocLevel)
-					.setDynamicTooltip()
-					.setDisabled(!this.plugin.settings.autoToc)
-					.onChange(async (value) => {
-						this.plugin.settings.tocLevel = value;
+						this.plugin.settings.indentation = value;
 						await this.plugin.saveSettings();
 					}),
 			);
@@ -668,14 +632,63 @@ class IDSidePanelSettingTab extends PluginSettingTab {
 					}),
 			);
 
+		containerEl.createEl("br");
+		const tocSection = containerEl.createEl("div", {
+			cls: "setting-item setting-item-heading",
+		});
+		const tocSectionInfo = tocSection.createEl("div", {
+			cls: "setting-item-info",
+		});
+		tocSectionInfo.createEl("div", {
+			text: "Table of contents",
+			cls: "setting-item-name",
+		});
+
 		new Setting(containerEl)
-			.setName("Indent notes")
-			.setDesc("Indents notes based on their id level.")
+			.setName("Table of contents title property")
+			.setDesc(
+				"Define the frontmatter field used as the title shown in the table of contents (case-insensitive).",
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder(TOC_TITLE_FIELD_DEFAULT)
+					.setValue(this.plugin.settings.tocField)
+					.onChange(async (value) => {
+						this.plugin.settings.tocField = value.trim();
+						await this.plugin.saveSettings();
+					}),
+			);
+
+		new Setting(containerEl)
+			.setName("Automatically include notes in table of contents")
+			.setDesc(
+				"If enabled, notes will be included in the table of contents based on their hierarchy level. " +
+					"If disabled, only notes with the table of contents title property will be shown.",
+			)
 			.addToggle((toggle) =>
 				toggle
-					.setValue(this.plugin.settings.indentation)
+					.setValue(this.plugin.settings.autoToc)
 					.onChange(async (value) => {
-						this.plugin.settings.indentation = value;
+						this.plugin.settings.autoToc = value;
+						await this.plugin.saveSettings();
+						this.display();
+					}),
+			);
+		new Setting(containerEl)
+			.setName("Table of contents level")
+			.setDesc(
+				"Defines which hierarchy level of notes should be included in the table of contents. " +
+					"A value of 1 includes only top-level notes (1, 2, …), 2 includes sub-levels (1.1, 1.2, …), and so on. " +
+					"Notes with the table of contents title property are always included.",
+			)
+			.addSlider((slider) =>
+				slider
+					.setLimits(1, 10, 1)
+					.setValue(this.plugin.settings.tocLevel)
+					.setDynamicTooltip()
+					.setDisabled(!this.plugin.settings.autoToc)
+					.onChange(async (value) => {
+						this.plugin.settings.tocLevel = value;
 						await this.plugin.saveSettings();
 					}),
 			);

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "note-id",
 	"name": "Note ID",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"minAppVersion": "0.15.0",
 	"description": "Displays notes by their ID, enabling structured sequences for manuscripts or Zettelkasten (\"Folgezettel\").",
 	"author": "Dominik Mayer",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-note-id",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "Displays notes by their ID, enabling structured sequences for manuscripts or Zettelkasten (\"Folgezettel\").",
 	"main": "main.js",
 	"scripts": {

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -347,7 +347,8 @@ createNote model path child =
                 Maybe.map NoteId.getNewIdInSequence id
 
         newUniqueId =
-            Maybe.map (getUniqueId model.notes) newId
+            newId
+                |> Maybe.andThen (getUniqueId model.notes)
 
         fileContent =
             case newUniqueId of
@@ -360,23 +361,22 @@ createNote model path child =
     ( model, Ports.createNote ( newPath, fileContent ) )
 
 
-getUniqueId : List NoteMeta -> String -> String
+getUniqueId : List NoteMeta -> String -> Maybe String
 getUniqueId notes id =
     -- Prevents infinite loops
     generateUniqueId notes id uniqueIdRetries
 
 
-generateUniqueId : List NoteMeta -> String -> Int -> String
+generateUniqueId : List NoteMeta -> String -> Int -> Maybe String
 generateUniqueId notes id remainingAttempts =
     if remainingAttempts <= 0 then
-        -- TODO: This should throw an error
-        id
+        Nothing
 
     else if isNoteIdTaken notes id then
         generateUniqueId notes (NoteId.getNewIdInSequence id) (remainingAttempts - 1)
 
     else
-        id
+        Just id
 
 
 isNoteIdTaken : List NoteMeta -> String -> Bool

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -463,7 +463,7 @@ sortNotes notes =
         (\a b ->
             case ( a.id, b.id ) of
                 ( Nothing, Nothing ) ->
-                    compare a.title b.title
+                    compare (String.toLower a.title) (String.toLower b.title)
 
                 ( Nothing, Just _ ) ->
                     GT


### PR DESCRIPTION
- Made title sorting case-insensitively
- Reorganized settings
- Prevented creation of duplicate note ids by defaulting to no id when no unique ID can be created
- Fixed bug where split levels were wrong after renaming a note or changing a note ID